### PR TITLE
Remove dot (.) from extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Default extension(s) for FileOpen component is now `csv` instead of `.csv`; the dot will be included in the extensions
+  and cause the opening to fail.
+
 ## [1.3.0] - 2023-08-03
 
 ### Added

--- a/Runtime/Scripts/FileOpen.cs
+++ b/Runtime/Scripts/FileOpen.cs
@@ -9,7 +9,7 @@ using Netherlands3D.JavascriptConnection;
 public class FileOpen : MonoBehaviour
 {
     [Tooltip("Allowed file input selections")]
-    [SerializeField] private string fileExtentions = ".csv";
+    [SerializeField] private string fileExtentions = "csv";
 
     [Tooltip("Allowed selection multiple files")]
     [SerializeField] private bool multiSelect = false;


### PR DESCRIPTION
The FileOpen service does not like it when there is a dot as the start of an extension, but somehow it snuck in. This change corrects the issue so that opened files will not feature two dots.