### PR TITLE
use result.contents

### DIFF
--- a/Runtime/Plugins/webgl/FileUploads.jslib
+++ b/Runtime/Plugins/webgl/FileUploads.jslib
@@ -188,7 +188,7 @@ mergeInto(LibraryManager.library, {
 
             var dbRequest = transaction.objectStore("FILE_DATA").get(indexedFilePath);
             dbRequest.onsuccess = function (e) {                
-                var blob = new Blob([e.target.result], { type: 'application/octetstream' });
+                var blob = new Blob([e.target.result.contents], { type: 'application/octetstream' });
 				var url = window.URL.createObjectURL(blob);
 				var onlyFileName = fileNameString.replace(/^.*[\\\/]/, '');
 				const a = document.createElement("a");


### PR DESCRIPTION
use result.contents, fixing issue where literal '[Object..' was saved as text to file