### PR TITLE
Add support for a headless method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2024-09-11
+
+### Added
+
+- Headless mode - if a FileOpen script is not attached to a UI Canvas it is considered to be headless and you can call 
+  the method "OpenFile" to start the file browser. This now works in-editor and in webgl builds
+
 ## [2.0.3] - 2024-07-25
 
 ### Fixed

--- a/Runtime/Plugins/webgl/StandaloneFileBrowser.jslib
+++ b/Runtime/Plugins/webgl/StandaloneFileBrowser.jslib
@@ -131,6 +131,13 @@ mergeInto(LibraryManager.library, {
         };
     },
 
+    /**
+     * Can be called by Unity to open (click) the file input with the given field name.
+     */
+    BrowseForFile: function (inputFieldName) {
+        document.getElementById(UTF8ToString(inputFieldName)).click();
+    },
+
     UploadFromIndexedDB: function (filePath, targetURL, callbackObject, callbackMethodSuccess, callbackMethodFailed) {
         var callbackObjectString = UTF8ToString(callbackObject);
         var callbackMethodSuccessString = UTF8ToString(callbackMethodSuccess);

--- a/Runtime/Scripts/DrawHTMLOverCanvas.cs
+++ b/Runtime/Scripts/DrawHTMLOverCanvas.cs
@@ -1,76 +1,102 @@
-﻿
-using System.Runtime.InteropServices;
-
+﻿using System.Runtime.InteropServices;
 using UnityEngine;
 
 
 namespace Netherlands3D.JavascriptConnection
 {
-	public class DrawHTMLOverCanvas : MonoBehaviour
-	{
-		[DllImport("__Internal")]
-		private static extern void AddFileInput(string inputName, string fileExtentions, bool multiSelect);
-		[DllImport("__Internal")]
-		private static extern void DisplayDOMObjectWithID(string id = "htmlID", string display = "none", float x = 0, float y = 0, float width = 0, float height = 0, float offsetX = 0, float offsetY = 0);
-		
-		[SerializeField] private string htmlObjectID = "";	
-		[SerializeField] private bool alignEveryUpdate = true;
+    public class DrawHTMLOverCanvas : MonoBehaviour
+    {
+        [DllImport("__Internal")]
+        private static extern void AddFileInput(string inputName, string fileExtentions, bool multiSelect);
 
-		private RectTransform rectTransform;
-		private RectTransform canvasRectTransform;
-		private Canvas rootCanvas;
+        [DllImport("__Internal")]
+        private static extern void DisplayDOMObjectWithID(string id = "htmlID", string display = "none", float x = 0,
+            float y = 0, float width = 0, float height = 0, float offsetX = 0, float offsetY = 0);
+
+        [SerializeField] private string htmlObjectID = "";
+        [SerializeField] private bool alignEveryUpdate = true;
+        /// <summary>
+        /// If this behaviour is headless, then we assume there is no Unity UI element to attach to and the HTML
+        /// element will remain hidden by keeping display on none.
+        ///
+        /// This field supercedes the alignEveryUpdate field, if this is true then the value in that field is not used.
+        /// </summary>
+        [SerializeField] private bool headless = false;
+
+        private RectTransform rectTransform;
+        private RectTransform canvasRectTransform;
+        private Canvas rootCanvas;
 
 #if !UNITY_EDITOR && UNITY_WEBGL
 		private void Update()
 		{
-			if (alignEveryUpdate)
+			if (!headless && alignEveryUpdate)
 				AlignHTMLOverlay();
 		}
+
 		private void OnEnable()
         {
 			rectTransform = GetComponent<RectTransform>();
-			rootCanvas = rectTransform.root.GetComponent<Canvas>();
-			canvasRectTransform = rootCanvas.GetComponentInParent<RectTransform>();
+            if (!rectTransform) {
+                headless = true;
+            } else {
+			    rootCanvas = rectTransform.root.GetComponent<Canvas>();
+			    canvasRectTransform = rootCanvas.GetComponentInParent<RectTransform>();
+            }
 
             AlignHTMLOverlay();
         }
+
         private void OnDisable()
         {
-            DisplayDOMObjectWithID(htmlObjectID,"none");
+            DisplayDOMObjectWithID(htmlObjectID, "none");
         }
 #endif
-		/// <summary>
-		/// Sets the target html DOM id to follow.
-		/// </summary>
-		/// <param name="id">The ID (without #)</param>
-		public void AlignObjectID(string id, bool alignEveryUpdate = true){
-			htmlObjectID = id;
-			this.alignEveryUpdate = alignEveryUpdate;
-		}
-		public void SetupInput(string fileInputName, string fileExtentions,bool multiSelect)
-		{
-			AddFileInput(fileInputName, fileExtentions, multiSelect);
-		}
+        /// <summary>
+        /// Sets the target html DOM id to follow.
+        /// </summary>
+        /// <param name="id">The ID (without #)</param>
+        /// <param name="headless">
+        /// Whether the HTML element should be hidden because it is invoked headless; if there is no rectTransform
+        /// then this is always true
+        /// </param>
+        public void AlignObjectID(string id, bool alignEveryUpdate = true, bool headless = false)
+        {
+            htmlObjectID = id;
+            this.alignEveryUpdate = alignEveryUpdate;
+            this.headless = !rectTransform || headless;
+        }
 
-		/// <summary>
-		/// Tell JavaScript to make a DOM object with htmlObjectID to align with the Image component
-		/// </summary>
-		private void AlignHTMLOverlay()
-		{
-			var canvasScaleFactor = rootCanvas.scaleFactor;	
-			float canvasheight = canvasRectTransform.rect.height * canvasScaleFactor;
-			float canvaswidth = canvasRectTransform.rect.width * canvasScaleFactor;
+        public void SetupInput(string fileInputName, string fileExtentions, bool multiSelect)
+        {
+            AddFileInput(fileInputName, fileExtentions, multiSelect);
+        }
 
-			Vector3[] corners = new Vector3[4];
-			rectTransform.GetWorldCorners(corners);
-			
-			DisplayDOMObjectWithID(htmlObjectID, "inline",
-				corners[0].x / canvaswidth,
-				corners[0].y / canvasheight,
-				(corners[2].x - corners[0].x) / canvaswidth,
-				(corners[2].y - corners[0].y) / canvasheight
-			);
-			
-		}
-	}
+        /// <summary>
+        /// Tell JavaScript to make a DOM object with htmlObjectID to align with the Image component
+        /// </summary>
+        private void AlignHTMLOverlay()
+        {
+            // If this is a headless component, ensure the DOM element is present, but hidden. 
+            if (headless)
+            {
+                DisplayDOMObjectWithID(htmlObjectID, "none");
+                return;
+            }
+
+            var canvasScaleFactor = rootCanvas.scaleFactor;
+            float canvasheight = canvasRectTransform.rect.height * canvasScaleFactor;
+            float canvaswidth = canvasRectTransform.rect.width * canvasScaleFactor;
+
+            Vector3[] corners = new Vector3[4];
+            rectTransform.GetWorldCorners(corners);
+
+            DisplayDOMObjectWithID(htmlObjectID, "inline",
+                corners[0].x / canvaswidth,
+                corners[0].y / canvasheight,
+                (corners[2].x - corners[0].x) / canvaswidth,
+                (corners[2].y - corners[0].y) / canvasheight
+            );
+        }
+    }
 }

--- a/Runtime/Scripts/FileOpen.cs
+++ b/Runtime/Scripts/FileOpen.cs
@@ -11,7 +11,7 @@ using Netherlands3D.JavascriptConnection;
 #endif
 public class FileOpen : MonoBehaviour
 {
-    [CanBeNull] private Button button;
+    private Button button;
 
     [DllImport("__Internal")]
     [UsedImplicitly]

--- a/Runtime/Scripts/FileOpen.cs
+++ b/Runtime/Scripts/FileOpen.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Runtime.InteropServices;
+using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.UI;
 using SFB;
@@ -8,6 +11,12 @@ using Netherlands3D.JavascriptConnection;
 #endif
 public class FileOpen : MonoBehaviour
 {
+    [CanBeNull] private Button button;
+
+    [DllImport("__Internal")]
+    [UsedImplicitly]
+    private static extern void BrowseForFile(string inputFieldName);
+
     [Tooltip("Allowed file input selections")]
     [SerializeField] private string fileExtentions = "csv";
 
@@ -19,9 +28,16 @@ public class FileOpen : MonoBehaviour
 #if !UNITY_EDITOR && UNITY_WEBGL
     private string fileInputName;
     private FileInputIndexedDB javaScriptFileInputHandler;
+#endif
 
-    void Start()
+    private void Awake()
     {
+        button = GetComponent<Button>();
+    }
+
+    private void Start()
+    {
+#if !UNITY_EDITOR && UNITY_WEBGL
         javaScriptFileInputHandler = FindObjectOfType<FileInputIndexedDB>(true);
         if (javaScriptFileInputHandler == null)
         {
@@ -35,21 +51,31 @@ public class FileOpen : MonoBehaviour
 
         DrawHTMLOverCanvas javascriptInput = gameObject.AddComponent<DrawHTMLOverCanvas>();
         javascriptInput.SetupInput(fileInputName, fileExtentions, multiSelect);
-        javascriptInput.AlignObjectID(fileInputName);
+
+        // if button is null, no visual element is attached and we should prevent the DrawHTMLOverCanvas from actually
+        // drawing something over the whole canvas. We still need the HTML input element though as that triggers the
+        // file upload dialog in `OpenFile()`
+        javascriptInput.AlignObjectID(fileInputName, button != null);
+#else
+        if (button) button.onClick.AddListener(OpenFile);
+#endif
     }
 
+#if !UNITY_EDITOR && UNITY_WEBGL
     public void ClickNativeButton()
     {
         javaScriptFileInputHandler.SetCallbackAddress(SendResults);
     }
-#else
-    private void Start()
-    {
-        GetComponent<Button>().onClick.AddListener(OpenFile);
-    }
+#endif
 
+    /// <summary>
+    /// Opens the File browser to pick a file to import
+    /// </summary>
     public void OpenFile()
     {
+#if !UNITY_EDITOR && UNITY_WEBGL
+        BrowseForFile("_" + gameObject.GetInstanceID());
+#else
         string[] fileExtentionNames = fileExtentions.Split(',');
         ExtensionFilter[] extentionfilters = new ExtensionFilter[1];
 
@@ -63,8 +89,8 @@ public class FileOpen : MonoBehaviour
             resultingFiles += System.IO.Path.GetFileName(filenames[i])+ ",";
         }
         SendResults(resultingFiles);
-    }
 #endif
+    }
 
     public void SendResults(string filePaths)
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eu.netherlands3d.filebrowser",
   "displayName": "Netherlands3D - Filebrowser",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "unity": "2022.2",
   "description": "A file browser for unity standalone and WebGL platforms",
   "type": "library",


### PR DESCRIPTION
By introducing a headless way of opening the file browser you can add a shortcut key to the application that will call the OpenFile method of the FileOpen class instead of it binding to a button.

Headless mode will also keep the HTML input element hidden, but calling OpenFile will force a 'click' event on it for the same effect